### PR TITLE
Add support for whitelisting entire IP ranges

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 ------------------------------------------------
 (unreleased)
 
+- Add support for whitelisting IP ranges. Single IP addresses can still
+  be used and mixed and matched with ranges.
+  [lgraf]
+
 - Move the [enable|disable]_two_factor_authentication actions before the
   logout action, that 'logout' is still at the bottom of the menu.
   [lgraf]

--- a/README.rst
+++ b/README.rst
@@ -153,11 +153,13 @@ If checked, two-step verification is globally force-enabled for all site users a
 longer have an option to disable it; this applies to all new users (just registered accounts)
 as well.
 
-White-listed IP addresses
+White-listed IP addresses or IP ranges
 ------------------------------------------------
-List of white-listed IP addresses - one at a line. If user comes from one of those,
+List of white-listed IP addresses or ranges - one per line. If user comes from one of those,
 the two-step verification is skipped even if user has enabled it or two-step verification
 is globally enabled.
+
+For specifying IP ranges the CIDR slash notation can be used, for example: ``192.168.0.0/16``.
 
 Extra
 ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'onetimepass==0.2.2',
         'ska>=1.1',
         'rebus>=0.1',
+        'py2-ipaddress>2.0.1',
     ],
     extras_require = {'test': ['plone.app.testing', 'plone.app.robotframework']},
     entry_points = """

--- a/src/collective/googleauthenticator/helpers.py
+++ b/src/collective/googleauthenticator/helpers.py
@@ -20,6 +20,7 @@ from plone import api
 from plone.registry.interfaces import IRegistry
 
 from ska import sign_url, validate_signed_request_data
+import ipaddress
 import rebus
 
 from collective.googleauthenticator.browser.controlpanel import IGoogleAuthenticatorSettings
@@ -461,7 +462,7 @@ def extract_ip_address_from_request(request=None):
         if len(proxies) > 0:
             ip = proxies[0]
 
-    return ip
+    return ipaddress.ip_address(ip)
 
 
 def get_ip_addresses_whitelist(request=None):
@@ -490,6 +491,17 @@ def get_ip_addresses_whitelist(request=None):
     return ip_addresses_whitelist or []
 
 
+def get_ip_ranges(list_of_networks):
+    """
+    Returns a list of IPv4Network or IPv6Network objects from a list of
+    single IP addresses ('127.0.0.1') or IP network specs ('127.0.0.0/8').
+
+    :param list list_of_networks:
+    :return list: A list of IPv4Network or IPv6Network objects.
+    """
+    return [ipaddress.ip_network(net) for net in list_of_networks]
+
+
 def is_whitelisted_client(request=None):
     """
     Checks if client's IP address is whitelisted.
@@ -498,13 +510,10 @@ def is_whitelisted_client(request=None):
     :return bool:
     """
     ip_addresses_whitelist = get_ip_addresses_whitelist(request=request)
+    whitelisted_ranges = get_ip_ranges(ip_addresses_whitelist)
 
     ip_address = extract_ip_address_from_request(request=request)
-
-    if ip_address in ip_addresses_whitelist:
-        return True
-
-    return False
+    return any(ip_address in ip_range for ip_range in whitelisted_ranges)
 
 
 def drop_login_failed_msg(request):

--- a/src/collective/googleauthenticator/helpers.py
+++ b/src/collective/googleauthenticator/helpers.py
@@ -268,18 +268,6 @@ def is_two_factor_authentication_globally_enabled():
     return settings.globally_enabled
 
 
-def get_white_listed_ip_addresses():
-    """
-    Gets list of white-listed IP addresses.
-
-    :return list:
-    """
-    settings = get_app_settings()
-    ip_addresses = settings.ip_addresses_whitelist
-    ip_addresses_list = ip_addresses.split('\n')
-    return ip_addresses_list
-
-
 def sign_user_data(request=None, user=None, url='@@google-authenticator-token'):
     """
     Signs the user data with `ska` package. The secret key is `secret_key` to

--- a/src/collective/googleauthenticator/tests/test_helpers.py
+++ b/src/collective/googleauthenticator/tests/test_helpers.py
@@ -1,0 +1,26 @@
+import unittest2 as unittest
+
+from collective.googleauthenticator.testing import \
+    COLLECTIVE_GOOGLEAUTHENTICATOR_INTEGRATION_TESTING
+from collective.googleauthenticator.tests.base import BaseTest
+
+from collective.googleauthenticator.helpers import get_ip_ranges
+from ipaddress import IPv4Network
+from ipaddress import IPv4Address
+
+
+class TestIPWhitelisting(unittest.TestCase, BaseTest):
+
+    layer = COLLECTIVE_GOOGLEAUTHENTICATOR_INTEGRATION_TESTING
+
+    def test_get_ip_ranges_always_returns_networks_and_accepts_single_ip(self):
+        ranges = get_ip_ranges(['127.0.0.1', '192.168.0.0/16'])
+        self.assertEqual(
+            [IPv4Network('127.0.0.1'), IPv4Network('192.168.0.0/16')],
+            ranges)
+
+    def test_get_ip_ranges_can_be_used_for_containment_testing(self):
+        ranges = get_ip_ranges(['127.0.0.1', '192.168.0.0/16'])
+        self.assertTrue(any(IPv4Address('127.0.0.1') in r for r in ranges))
+        self.assertTrue(any(IPv4Address('192.168.1.1') in r for r in ranges))
+        self.assertFalse(any(IPv4Address('10.0.0.0') in r for r in ranges))


### PR DESCRIPTION
This PR extends the support for whitelisting IPs to also support IP ranges.

Whitelisting single IP addresses still works exactly the same way as it did before, so no change is required to existing user's configurations.

IP ranges can be specified using the CIDR slash notation, and mixed and matched with single IP addresses. For example:

```
10.1.1.123
192.168.0.0/16
127.0.0.1
```

Internally, a single IP address now just gets resolved to a network with one address. For resolving address specifications, [`py2-ipaddress`](https://pypi.python.org/pypi/py2-ipaddress/) (the backport to Python 2 of the Py 3 standard library's `ipaddress` module) is used.

@barseghyanartur 