### PR TITLE
Use the default formatting for the user object in logging, simpler is…

### DIFF
--- a/src/collective/googleauthenticator/pas_plugin.py
+++ b/src/collective/googleauthenticator/pas_plugin.py
@@ -87,7 +87,7 @@ class GoogleAuthenticatorPlugin(BasePlugin):
 
         user = api.user.get(username=login)
 
-        logger.debug("Found user: {0}".format(user.getProperty('username')))
+        logger.debug("Found user: {0}".format(user)
 
         two_factor_authentication_enabled = user.getProperty(
             'enable_two_factor_authentication')


### PR DESCRIPTION
… better

When playing around with this plugin in a pristine Plone 4.3 install, I noticed that the `username` property does not exist for portal members. The missing property results in a `ValueError` which makes the plugin skip the second auth step despite having it enabled.

This change still logs the username, but in a more fault tolerant way.